### PR TITLE
fix: restore clipboard pre-fill and fix Claude initial submission

### DIFF
--- a/bin/swift_prompt.sh
+++ b/bin/swift_prompt.sh
@@ -45,7 +45,11 @@ fi
 # ---------- build prompt ------------------------------------------------------
 
 TASK_NAME=$(default_task_name)
-PROMPT_TEXT=$(clipboard_contents)
+if [[ -n "${LLMB_DEFAULT_PROMPT:-}" ]]; then
+  PROMPT_TEXT="$LLMB_DEFAULT_PROMPT"
+else
+  PROMPT_TEXT=$(clipboard_contents)
+fi
 
 # Invoke swiftDialog.
 #   --json   → print JSON to stdout

--- a/llm_burst/cli.py
+++ b/llm_burst/cli.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
 import sys
+import pyperclip
 from typing import Any, Dict, Union, Optional
 from uuid import uuid4
 
@@ -57,10 +59,20 @@ def prompt_user() -> Dict[str, Any]:
     if not shutil.which("dialog"):
         raise FileNotFoundError("swiftDialog not installed")
 
+    # Grab clipboard to pre-seed the dialog (falls back silently)
+    try:
+        clipboard_text: str = pyperclip.paste()
+    except Exception:
+        clipboard_text = ""
+
+    env = os.environ.copy()
+    env["LLMB_DEFAULT_PROMPT"] = clipboard_text
+
     result = subprocess.run(
         [str(SWIFT_PROMPT_SCRIPT)],
         capture_output=True,
         text=True,
+        env=env,
     )
 
     # Forward any error output to the calling terminal.

--- a/llm_burst/providers/__init__.py
+++ b/llm_burst/providers/__init__.py
@@ -100,7 +100,7 @@ _PROVIDER_CONFIG: dict[LLMProvider, tuple[str, str | None, str, str | None]] = {
     LLMProvider.CLAUDE: (
         claude.SUBMIT_JS,
         claude.FOLLOWUP_JS,
-        "(function(txt) {{ document.execCommand('insertText', false, txt); }})({prompt})",
+        "automateClaudeInteraction({research})",
         "claudeFollowUpMessage({prompt})",
     ),
     LLMProvider.GROK: (
@@ -125,4 +125,29 @@ def get_injector(provider: LLMProvider):
         cfg = _PROVIDER_CONFIG[provider]
     except KeyError as exc:
         raise KeyError(f"Unknown provider: {provider}") from exc
-    return _build_injector(*cfg)
+    
+    base_injector = _build_injector(*cfg)
+    
+    # Special behaviour for Claude: after JS focuses the editor, paste + send.
+    if provider is LLMProvider.CLAUDE:
+        
+        async def _claude_inject(page: Page, prompt: str, opts: "InjectOptions") -> None:  # noqa: D401
+            await base_injector(page, prompt, opts)
+            
+            # Only for initial submission – follow-ups already handled in JS
+            if not opts.follow_up:
+                try:
+                    import pyperclip
+                    pyperclip.copy(prompt)
+                except Exception:
+                    # Non-fatal – continue without clipboard
+                    pass
+                
+                # Give the browser a brief moment to settle focus
+                await page.wait_for_timeout(100)
+                await page.keyboard.press("Meta+V")
+                await page.keyboard.press("Enter")
+        
+        return _claude_inject
+    
+    return base_injector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic>=2.5.0",
     "rich>=13.5.0",
     "aiohttp>=3.8.0",
+    "pyperclip>=1.8.0",  # Clipboard helper
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Restores clipboard pre-fill functionality that was lost in the Python migration
- Fixes Claude's initial prompt submission to use the reliable paste method instead of deprecated execCommand
- Brings Python implementation in line with original Keyboard Maestro behavior

## Problem
The Python implementation had two critical regressions from the original KM macros:
1. **Clipboard pre-fill was lost**: Users had to manually paste content into the prompt dialog
2. **Claude submissions were unreliable**: Used deprecated `document.execCommand` instead of the paste method

## Solution

### Clipboard Pre-fill
- Added `pyperclip` dependency for cross-platform clipboard access
- Modified `cli.py` to read clipboard content and pass it via environment variable
- Updated `swift_prompt.sh` to use the environment variable when available

### Claude Initial Submission
- Fixed the submit template to call `automateClaudeInteraction()` properly
- Implemented paste simulation using Playwright keyboard actions (Meta+V, Enter)
- Created a special wrapper for Claude that handles the paste after focusing the input

## Test plan
- [x] Existing test suite passes
- [x] Manual verification of clipboard pre-fill
- [x] Manual verification of Claude prompt submission
- [ ] Test on actual Claude.ai website
- [ ] Test with various prompt sizes and special characters

🤖 Generated with [Claude Code](https://claude.ai/code)