### PR TITLE
fix(ci): align tests workflow with pnpm Playwright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,27 +9,26 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
         with:
-          python-version: "3.11"
+          version: 10.15.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pip install -e .
-          pip install pytest pytest-asyncio pytest-playwright
-          python -m playwright install --with-deps chromium
+        run: pnpm install --frozen-lockfile
 
-      - name: Run pytest (unit tests)
+      - name: Install Playwright browser
+        run: pnpm exec playwright install chromium
+
+      - name: Run Playwright tests
         env:
-          PYTHONUNBUFFERED: "1"
-        run: |
-          pytest -v -m unit tests/test_browser.py
-      
-      - name: Run pytest (integration tests - headed)
-        env:
-          PYTHONUNBUFFERED: "1"
-        run: |
-          pytest -v --headed -m "not unit"
+          CI: "true"
+        run: pnpm run test:playwright


### PR DESCRIPTION
Root cause: the `tests` workflow was still a Python/`pytest` pipeline and failed on `pip install -e .` because this repo has no `setup.py` or `pyproject.toml`.

Evidence:
- PR #19 and post-merge `main` both failed on the same `pip install -e .` step.
- An older `main` run on 2026-02-12 failed the same way, before the runner-variable change landed.

This PR updates only `.github/workflows/test.yml` to use the repo's actual toolchain: Node + pnpm + Playwright.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the GitHub Actions workflow, but may change which tests run and their runtime dependencies on CI runners.
> 
> **Overview**
> Updates `.github/workflows/test.yml` to stop installing/running `pytest` and instead run the repo’s Playwright suite via `pnpm`.
> 
> The workflow now sets up `pnpm` (pinned) and Node 20 with pnpm caching, installs dependencies with `--frozen-lockfile`, installs the Chromium browser via Playwright, and executes `pnpm run test:playwright` with `CI=true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fc0dc2a2dfd5c13fa24f92089e6b20230727a4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration testing infrastructure from Python-based execution to Node/pnpm with Playwright testing pipeline. Updated GitHub Actions to latest versions for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->