### PR TITLE
fix(ci): remove redundant pnpm version config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.15.1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Follow-up to #20.

The stale Python workflow issue is already fixed on `main`, but the new CI workflow failed during `pnpm/action-setup@v4` because `package.json` already pins `packageManager` and the action rejects a second explicit `version`.

This PR removes only that redundant `version` field so the Playwright-based `tests` workflow can proceed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it just relies on the repo-pinned pnpm version to avoid `pnpm/action-setup` conflicts and should only affect workflow setup behavior.
> 
> **Overview**
> Removes the explicit `version` from the `pnpm/action-setup@v4` step in `.github/workflows/test.yml`, letting the workflow use the pnpm version pinned by `package.json`.
> 
> This prevents CI failures caused by specifying pnpm twice, while leaving the rest of the Node/Playwright test job unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b5f4ac80951e6f49fabe510458704aa048e2d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->