### PR TITLE
chore: add Codex MCP config and restore format gate

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,16 @@
+[mcp_servers.chrome-devtools]
+command = "npx"
+args = [
+    "chrome-devtools-mcp@latest",
+    "--browserUrl",
+    "http://127.0.0.1:9222",
+]
+
+[mcp_servers.playwright]
+command = "npx"
+args = [
+    "-y",
+    "@playwright/mcp@latest",
+    "--cdp-endpoint",
+    "http://127.0.0.1:9222",
+]

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,14 +17,14 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,10 +36,9 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Pin a currently supported model so action-default drift cannot break reviews.
+          model: 'claude-fable-5'
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide feedback on:
@@ -48,12 +47,12 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
-          
+
           # Optional: Customize review based on file types
           # direct_prompt: |
           #   Review this PR focusing on:
@@ -61,16 +60,16 @@ jobs:
           #   - For API endpoints: Security, input validation, and error handling
           #   - For React components: Performance, accessibility, and best practices
           #   - For tests: Coverage, edge cases, and test quality
-          
+
           # Optional: Different prompts for different authors
           # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
+
           # Optional: Add specific tools for running tests or linting
           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
+
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&

--- a/chrome_ext/content/injectors/claude.js
+++ b/chrome_ext/content/injectors/claude.js
@@ -400,9 +400,7 @@
     try {
       const payload = buildLexicalStateFromText(text);
       const state =
-        typeof editor.parseEditorState === 'function'
-          ? editor.parseEditorState(payload)
-          : payload;
+        typeof editor.parseEditorState === 'function' ? editor.parseEditorState(payload) : payload;
       const result = editor.setEditorState(state);
       if (result && typeof result.then === 'function') {
         await result;
@@ -520,7 +518,10 @@
       if (parent) {
         observer.observe(parent, { childList: true, subtree: false });
       }
-      observer.observe(element, { attributes: true, attributeFilter: ['contenteditable', 'aria-hidden'] });
+      observer.observe(element, {
+        attributes: true,
+        attributeFilter: ['contenteditable', 'aria-hidden'],
+      });
       editorTracker.observer = observer;
     } catch {
       editorTracker.observer = null;
@@ -687,8 +688,12 @@
 
     for (const combo of combos) {
       try {
-        target.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...combo }));
-        target.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, cancelable: true, ...combo }));
+        target.dispatchEvent(
+          new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...combo }),
+        );
+        target.dispatchEvent(
+          new KeyboardEvent('keyup', { bubbles: true, cancelable: true, ...combo }),
+        );
       } catch {
         /* ignore */
       }
@@ -758,9 +763,9 @@
   async function findToolsMenuButton(timeout = 12000) {
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
-      const direct = /** @type {HTMLButtonElement | null} */ (findEnabledButton(
-        TOOLS_MENU_BUTTON_SELECTORS,
-      ));
+      const direct = /** @type {HTMLButtonElement | null} */ (
+        findEnabledButton(TOOLS_MENU_BUTTON_SELECTORS)
+      );
       if (direct) return direct;
 
       const fallback = /** @type {HTMLButtonElement | null} */ (
@@ -816,11 +821,7 @@
         const text = (candidate.textContent || '').toLowerCase();
         const aria = (candidate.getAttribute('aria-label') || '').toLowerCase();
         const testId = (candidate.getAttribute('data-testid') || '').toLowerCase();
-        if (
-          text.includes('research') ||
-          aria.includes('research') ||
-          testId.includes('research')
-        ) {
+        if (text.includes('research') || aria.includes('research') || testId.includes('research')) {
           return candidate;
         }
       }
@@ -867,7 +868,11 @@
 
   function isResearchPillActive(button) {
     if (!(button instanceof HTMLElement)) return false;
-    const dataState = (button.getAttribute('data-state') || button.dataset?.state || '').toLowerCase();
+    const dataState = (
+      button.getAttribute('data-state') ||
+      button.dataset?.state ||
+      ''
+    ).toLowerCase();
     if (['on', 'active', 'true', 'checked', 'selected'].includes(dataState)) return true;
     const ariaPressed = button.getAttribute('aria-pressed');
     if (ariaPressed === 'true') return true;
@@ -897,7 +902,12 @@
     const ariaPressed = button.getAttribute('aria-pressed');
     if (ariaPressed === 'true') return true;
     const dataState = (button.getAttribute('data-state') || '').toLowerCase();
-    if (dataState === 'on' || dataState === 'true' || dataState === 'checked' || dataState === 'active') {
+    if (
+      dataState === 'on' ||
+      dataState === 'true' ||
+      dataState === 'checked' ||
+      dataState === 'active'
+    ) {
       return true;
     }
     const ariaChecked = button.getAttribute('aria-checked');
@@ -946,7 +956,8 @@
       120,
     ).catch(() => null);
     const active =
-      isResearchToggleActive(/** @type {HTMLElement | null} */ (researchButton)) || isResearchActive();
+      isResearchToggleActive(/** @type {HTMLElement | null} */ (researchButton)) ||
+      isResearchActive();
     if (!wasExpanded) {
       await closeToolsMenu(button);
     }
@@ -988,7 +999,9 @@
     await ensureElementInteractable(pill);
     simulateButtonClick(pill);
 
-    const activated = await waitUntil(() => isResearchPillActive(pill), 2500, 120).catch(() => false);
+    const activated = await waitUntil(() => isResearchPillActive(pill), 2500, 120).catch(
+      () => false,
+    );
     if (activated) {
       return { attempted: true, success: true, method: 'pill' };
     }
@@ -1006,7 +1019,12 @@
       if (pillOutcome.attempted) {
         if (pillOutcome.success) {
           console.log('✅ Research mode enabled via model pill');
-          return { success: true, method: pillOutcome.method || 'pill', alreadyEnabled: pillOutcome.alreadyEnabled, warnings };
+          return {
+            success: true,
+            method: pillOutcome.method || 'pill',
+            alreadyEnabled: pillOutcome.alreadyEnabled,
+            warnings,
+          };
         }
         warnings.push('Research pill activation fallback to tools menu');
       }
@@ -1424,7 +1442,9 @@
     if (!sendButton) {
       const fallback = findSendButtonCandidate({ requireEnabled: false });
       if (fallback) {
-        warnings.push('Claude send control remained disabled after waiting; attempting keyboard fallback');
+        warnings.push(
+          'Claude send control remained disabled after waiting; attempting keyboard fallback',
+        );
       } else {
         warnings.push('Claude send control not found');
       }


### PR DESCRIPTION
## Summary

- add the project MCP servers in Codex's repository config format, matching the tracked `.mcp.json`
- apply the repository's existing Prettier configuration to the Claude injector so the format gate passes
- pin the Claude review workflow to smoke-tested `claude-fable-5` after its stale action default returned `404 model not found`

## Validation

- `pnpm exec prettier --check .github/workflows/claude-code-review.yml`
- `actionlint .github/workflows/claude-code-review.yml`
- `pnpm format`
- `pnpm verify` (build, TypeScript, ESLint, 20 Playwright tests)

## Publication

- workflow-only top commit reviewed and applied server-side by secure-gate review `por_gel_285caf28feea77fe3abc2eb94982f3ac`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added local browser automation configuration to support Chrome DevTools and Playwright workflows.
  * Pinned the automated code-review model for more consistent review behavior.
* **Refactor**
  * Improved formatting and readability across browser interaction and research-mode handling without changing user-facing behavior.
  * Maintained existing editor interaction, send, and research workflows while clarifying their implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->