### PR TITLE
chore: add Dependabot npm and github-actions coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Add Dependabot version updates for the real package ecosystems in this repo (`npm` at `/`, `github-actions` at `/`). Groups are restricted to `minor` and `patch` so majors stay ungrouped and manual.

The auto-merge workflow is **omitted**. `allow_auto_merge` was `false` before this PR; `PATCH repos/johnhughes3/llm-burst allow_auto_merge=true` (and `gh repo edit --enable-auto-merge`) returned **403 Resource not accessible by integration**. Re-read is still `false`. Per the rollout plan, Dependabot config still lands; merge authority is not claimed.

## Preflight

### Manifests actually found

| Path | Ecosystem | Action |
|---|---|---|
| `/package.json` + `/pnpm-lock.yaml` | npm | Dependabot block at `/` |
| `/docs/reference/extension-ui-template/package.json` + `package-lock.json` | npm (static docs reference / Vite starter snapshot, not an active runtime package) | Not scanned |
| `/go.mod`, `pyproject.toml`/`uv.lock`/`requirements.txt`, `Cargo.toml`, `Dockerfile*`, `docker-compose.yml`/`compose.yml`, `Package.swift`, `*.tf`, Xcode `.xcodeproj` | none | — |
| `.github/workflows/*.yml` | github-actions | Dependabot block at `/` |

### CI workflows (origin/main)

- `tests` (`.github/workflows/test.yml`): `on: push` and `on: pull_request`. Job `pytest` on `macos-latest` (pnpm + Playwright). This is the only workflow on default branch after #24 removed Claude/Codex workflows.
- No `dependabot-auto-merge` workflow (intentionally omitted).

### Default-branch rules (ruleset `main` id 7157863)

- Target: `~DEFAULT_BRANCH`
- Rules: `deletion`, `non_fast_forward`, `required_linear_history`
- **No required status checks**
- **No required reviews**
- Classic branch protection: `403 Resource not accessible by integration` (not configured / not readable)
- Check-runs **can** be queried (`GET /repos/johnhughes3/llm-burst/commits/<sha>/check-runs` works). Head of `main` currently has completed successful runs for `pytest`, CodeQL Analyze (javascript-typescript, actions), Socket Security, and Upload Results.

### `allow_auto_merge`

- Before: `false`
- `gh api -X PATCH repos/johnhughes3/llm-burst -f allow_auto_merge=true`: **403 Resource not accessible by integration**
- `gh repo edit johnhughes3/llm-burst --enable-auto-merge`: **403**
- After re-read: `false`
- Token `permissions` on the repo: admin/maintain/push/pull/triage all `false` for the integration (routine broker has no Administration)

### Actionlint / SHA-pin / workflow tests

- This repo has **no** actionlint, SHA-pin, or workflow test suite on origin/main (only `.github/workflows/test.yml`).
- This PR adds YAML config only, no workflow, so there is nothing to actionlint.
- Local schema check: parsed `.github/dependabot.yml` (version 2, npm + github-actions at `/`, groups `update-types: [minor, patch]`, `open-pull-requests-limit: 5`).

## Policy notes

- Auto-land would have been limited to `version-update:semver-patch` and `version-update:semver-minor`. Empty `update-type` and every major stay manual.
- No `pull_request_target`, no PAT, no `--admin` merge.
- Cooldown is not applied here (plan cooldown is for habeas, system-cloudflare, and secure-gate only).