### PR TITLE
ci: pin CodeQL to ubicloud-standard-2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "41 9 * * 5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 90
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why

GitHub-hosted CodeQL (`ubuntu-latest` / default setup `runner_type=standard`) ran recently on this repo. The owner asked Code scanning CodeQL onto `ubicloud-standard-2` or `vars.CI_RUNNER`.

Default setup cannot select Ubicloud labels (`API 422: runner with that label is not assigned to the repository`), so default setup was disabled and advanced setup is the replacement.

This is **Code scanning CodeQL**, not GitHub Code Quality. Code Quality default setup still cannot retarget without a self-hosted runner assigned to the repo.

For public `johnhughes3` repos the org `CI_RUNNER` variable is private-visibility and does not resolve, so this workflow pins `runs-on: ubicloud-standard-2` rather than `vars.CI_RUNNER`.

## What

- Add `.github/workflows/codeql.yml` as advanced CodeQL setup
- Analyze `actions` and `javascript-typescript` with `build-mode: none`
- Run on `ubicloud-standard-2` (push/PR to `main`, weekly schedule, `workflow_dispatch`)